### PR TITLE
Typo "Max OS X" => "Mac OS X"

### DIFF
--- a/_moppris/profile.jade
+++ b/_moppris/profile.jade
@@ -61,7 +61,7 @@ include _utils.jade
                 .pure-u-8-24: +icon-showcase('devicon-git-plain', 'Git')
                 .pure-u-8-24: +icon-showcase('devicon-chrome-plain', 'Chrome')
                 .pure-u-8-24: +icon-showcase('devicon-linux-plain', 'Linux')
-                .pure-u-8-24: +icon-showcase('devicon-apple-original', 'Max OS X')
+                .pure-u-8-24: +icon-showcase('devicon-apple-original', 'Mac OS X')
                 .pure-u-8-24: +icon-showcase('devicon-windows8-original', 'Windows')
             +item-line('Neovim')
             +item-line('Gnuplot')


### PR DESCRIPTION
Hi!

I found a typo, so I just corrected a typo: "Ma**x** OS X" => "Ma**c** OS X". However, macOS may be better than Mac OS X (<https://www.wikiwand.com/en/MacOS>).